### PR TITLE
Update Tar Review

### DIFF
--- a/zip/zipTarReview.tex
+++ b/zip/zipTarReview.tex
@@ -55,9 +55,9 @@ Upon successful completion of this review, you should be able to:
 
 \section*{Introduction \label{sec:Introduction}}
 
-GZIP(GNU Zip) and Tar ( Tape Achiever) are two programs used in combination
-to create a compressed archive or also known as zip file. Compressed
-archives are a simple method of keeping all your information together
+GZIP(GNU Zip) and Tar (Tape Archiver) are two programs \it{often} used in
+combination to create a compressed archive or also known as zip file.
+Compressed archives are a simple method of keeping all your information together
 and reducing the file size. Compressing your files minimizes the space
 the files use on the system and the time to transfer the files. The
 first part of creating a compressed archive is to organize all of
@@ -67,14 +67,14 @@ all the files within the tar file using gzip or an equivalent program.
 Tar archives should use the extension .tar, while GZIP compressed
 files will have the extension .gz. If Tar and GZIP have been used
 in combination, the compressed archive will often have both extensions
-in the form ``.tar.gz''. Tar and GZIP are so frequently used together,
-that it is easy to forget that are different programs, especially
+in the form ``.tar.gz'', or ``.tgz". Tar and GZIP are so frequently used
+together, that it is easy to forget that are different programs, especially
 as many of the command-line arguments provide by tar support functionality
 available in GZIP.
 
 \section*{Getting Started \label{sec:Getting-Started}}
 
-To get start lets create a tar archive from a programming project,
+To get started, let's create a tar archive from a programming project,
 with the following command line call:
 
 \begin{lstlisting}[language=make,tabsize=4,frame=TB]
@@ -83,9 +83,10 @@ tar cvf myProject.tar ./myProjectDirectory
 
 The command-line arguments perform the following actions:
 \begin{lyxlist}{00.00.0000}
-\item [{c}] create a new .tar archive named myProject.tar
+\item [{c}] create a new .tar archive
 \item [{v}] the verbose flag provides additional output from the program
-\item [{f}] indicates the tar filename was provided
+\item [{f}] indicates the tar archive should be named by the following
+            string, in this case ``myProject.tar"
 \end{lyxlist}
 This call will create a tar file named myProject.tar, when the program
 runs it will output all files and paths that have been included in
@@ -96,13 +97,13 @@ compressed. If you want to list or extract the contents of a compressed
 gz file, you can use the following commands.
 
 \begin{lstlisting}[language=make,tabsize=4,frame=TB]
-// Create a compressed tar
+# Create a compressed tar
 tar cvfz myProject.tar.gz ./myProjectDirectory
 
-// List files in compressed tar
+# List files in compressed tar
 gzip -l myProject.tar.gz
 
-//Extract tar file from compressed file
+# Extract tar file from compressed file
 gzip -d myProject.tar.gz
 \end{lstlisting}
 
@@ -119,6 +120,12 @@ tar xvf myProject.tar.gz
 tar xvf myProject.tar
 \end{lstlisting}
 
+On most machines, you can extract the files from the compressed archive
+all in one go by running
+\begin{lstlisting}[language=make,tabsize=4,frame=TB]
+tar xvzf myProject.tar.gz
+\end{lstlisting}
+
 
 \subsection*{Variables \label{subsec:Variables}}
 
@@ -129,10 +136,10 @@ some of the more common command-line arguments:
 \item [{-r}] append files to archive
 \item [{-t}] list the contents of tar
 \item [{-u}] update only archive that are new or changed files
-\item [{-x}] extract files from tar or gz
-\item [{-f}] give filename of tar or zip
+\item [{-x}] extract files from an archive
+\item [{-f}] give filename to tar or zip (last argument before filename)
 \item [{-c}] create an archive
-\item [{-z}] compress the tar files
+\item [{-z}] compress the tar files using gzip
 \item [{-v}] verbose
 \item [{\textendash delete}] delete files form archives
 \end{lyxlist}

--- a/zip/zipTarReview.tex
+++ b/zip/zipTarReview.tex
@@ -38,7 +38,7 @@
 
 Tar and GZIP are two programs used to create and extract compressed
 archives of files. This process is also known as zipping or compressing
-files, is the process of grouping and compress the size of a set of
+files, and is the process of grouping and compressing the size of a set of
 files. In order to submit your labs and assignments throughout the
 course, you will need to submit compressed archived files. This review
 introduces the basic usage concepts of Tar and GZIP tools, including
@@ -49,16 +49,16 @@ a ``Getting Started'' example, and some useful common-line arguments.
 Upon successful completion of this review, you should be able to:
 \begin{itemize}
 \item recognize the benefits of using an archiving program
-\item archive and underachieve your projects for submission
+\item archive and unarchive your projects for submission
 \item apply command-line arguments to modify archives
 \end{itemize}
 
 \section*{Introduction \label{sec:Introduction}}
 
-GZIP(GNU Zip) and Tar (Tape Archiver) are two programs \it{often} used in
+GZIP (GNU Zip) and Tar (Tape Archiver) are two programs \textit{often} used in
 combination to create a compressed archive or also known as zip file.
-Compressed archives are a simple method of keeping all your information together
-and reducing the file size. Compressing your files minimizes the space
+Compressed archives are a simple method of keeping all your information
+together and reducing the file size. Compressing your files minimizes the space
 the files use on the system and the time to transfer the files. The
 first part of creating a compressed archive is to organize all of
 the desired files into a single archive or tar file, this uses the
@@ -78,7 +78,7 @@ To get started, let's create a tar archive from a programming project,
 with the following command line call:
 
 \begin{lstlisting}[language=make,tabsize=4,frame=TB]
-tar cvf myProject.tar ./myProjectDirectory 
+tar cvf myProject.tar ./myProjectDirectory
 \end{lstlisting}
 
 The command-line arguments perform the following actions:
@@ -107,27 +107,27 @@ gzip -l myProject.tar.gz
 gzip -d myProject.tar.gz
 \end{lstlisting}
 
-Extract a tar.gz file using gzip will give you the original tar archive,
+Extracting a tar.gz file using gzip will give you the original tar archive,
 however, you'll probably want to extract the original contents from
 within the tar file. To remove the contents from a tar or tar.gz file
-use the 'x' command-line parameter 
+use the 'x' command-line parameter
 
 \begin{lstlisting}[language=make,tabsize=4,frame=TB]
-// Extract file contents from compression file
+# Extract file contents from compression file
 tar xvf myProject.tar.gz
 
-// Extract file from tar
+# Extract file from tar
 tar xvf myProject.tar
 \end{lstlisting}
 
 On most machines, you can extract the files from the compressed archive
-all in one go by running
+all in one go by running the following command
 \begin{lstlisting}[language=make,tabsize=4,frame=TB]
 tar xvzf myProject.tar.gz
 \end{lstlisting}
 
 
-\subsection*{Variables \label{subsec:Variables}}
+\subsection*{Arguments \label{subsec:Arguments}}
 
 Tar contains several useful command-line arguments, this list contains
 some of the more common command-line arguments:


### PR DESCRIPTION
## Summary of changes

I fixed some typos and clarified a bit of potentially confusing language, and also added an example using `tar xvzf ...` to extract a gzipped tar file all in one go. Students unfamiliar with tar will likely find this more useful than the two-step process.

I also modified the descriptions of some of the command-line arguments, to be more in-line with the actual functionality.

It is also important for students to know that the `f` arg should be last argument before the archive name, and the directory/file listing to be compressed. I've attempted to make this more clear.